### PR TITLE
Add README.rst to the manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-recursive-include tests *.py *.html *.txt *.json
+recursive-include tests *.py *.html *.txt *.json README.rst
 include base_theme/*
 include base_theme/static/*
 include base_theme/templates/*


### PR DESCRIPTION
`setup.py` includes a function called `long_desc` which tries to read from `README.rst`. Because `README.rst` is not part of the manifest, an `IOError` is raised when trying to install from PyPI.

```
$ pip install flask-themes2
Downloading/unpacking flask-themes2
  Downloading Flask-Themes2-0.1.1.tar.gz
  Storing download in cache at /Users/dirn/.pip/cache/http%3A%2F%2Fpypi.python.org%2Fpackages%2Fsource%2FF%2FFlask-Themes2%2FFlask-Themes2-0.1.1.tar.gz
  Running setup.py egg_info for package flask-themes2
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "/Users/dirn/.virtualenvs/78bc249a2114e3fa/build/flask-themes2/setup.py", line 22, in <module>
        "long_description": long_desc(),
      File "/Users/dirn/.virtualenvs/78bc249a2114e3fa/build/flask-themes2/setup.py", line 9, in long_desc
        with open('README.rst', 'rb') as f:
    IOError: [Errno 2] No such file or directory: 'README.rst'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "/Users/dirn/.virtualenvs/78bc249a2114e3fa/build/flask-themes2/setup.py", line 22, in <module>

    "long_description": long_desc(),

  File "/Users/dirn/.virtualenvs/78bc249a2114e3fa/build/flask-themes2/setup.py", line 9, in long_desc

    with open('README.rst', 'rb') as f:

IOError: [Errno 2] No such file or directory: 'README.rst'

----------------------------------------
Command python setup.py egg_info failed with error code 1 in /Users/dirn/.virtualenvs/78bc249a2114e3fa/build/flask-themes2
Storing complete log in /Users/dirn/.pip/pip.log
```
